### PR TITLE
Use PyROOT to write to root file with the old compression method.

### DIFF
--- a/demo/write_to_root_file.py
+++ b/demo/write_to_root_file.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
-import root_numpy
+import sys
+sys.path.insert(0, '..')
+
 import numpy
+from utils.io import array2root
 
 # folding_weights.dtype = [('weight', numpy.float64)]
 test_tree = numpy.array([(1, 2.5, 3.4), (4, 5, 6.8)],
                         dtype=[('a', int), ('b', float), ('c', float)])
 
 # Write the new weights to a root tree
-root_numpy.array2root(test_tree,
-                      'test_tree.root', 'test_tree', mode='recreate')
+array2root(test_tree, 'test_tree.root', 'test_tree', mode='recreate')

--- a/utils/io.py
+++ b/utils/io.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import ROOT
+from root_numpy import array2tree
+
+
+def array2root(array, filename,
+               treename='tree',
+               mode='update', compression='zlib'):
+    if compression == 'zlib':
+        file = ROOT.TFile(filename, mode, "", 101)
+    else:
+        file = ROOT.TFile(filename, mode)
+
+    tree = array2tree(array, name=treename)
+
+    file.Write()
+    file.Close()


### PR DESCRIPTION
A drop-in replacement method for `array2root` is implemented in `utils/io.py`. By default, this method will compress the root file with `zlib`, making the file compatible with older `ROOT`.

The example on reading `ROOT` files in `demo` has been update. Please refer to that file for usage.