### PR TITLE
Workaround ROOT file compression incompatibility

### DIFF
--- a/demo/write_to_root_file.py
+++ b/demo/write_to_root_file.py
@@ -13,14 +13,16 @@ test_array = numpy.array([(1, 2.5, 3.4), (4, 5, 6.8)],
                         dtype=[('a', int), ('b', float), ('c', float)])
 
 # Write the new weights to a root tree
-array2root(test_array, 'test_tree.root', 'test_tree', mode='recreate')
+array2root(test_array, 'test_tree-zlib.root', 'test_tree', mode='recreate')
+array2root(test_array, 'test_tree-lzma.root', 'test_tree', mode='recreate',
+           compression='lzma')
 
 # Now read from the newly-created root file, and compare
-test_array_read = root2array('test_tree.root', 'test_tree',
+test_array_read = root2array('test_tree-zlib.root', 'test_tree',
                              branches=['a', 'b', 'c'])
 print('Test if two arrays equal: %s' %
       numpy.array_equal(test_array, test_array_read))
 
 # Now try to update the existing root file
 test_array_new = numpy.array([(3,), (9,)], dtype=[('d', int)])
-array2root(test_array_new, 'test_tree.root', 'test_tree')
+array2root(test_array_new, 'test_tree-zlib.root', 'test_tree')

--- a/utils/io.py
+++ b/utils/io.py
@@ -16,10 +16,12 @@ def array2root(array, filename,
     if not target_file.is_file():
         mode = 'recreate'
 
+    # Since we explicitly specify the compression algorithm, it is always
+    # backward compatible.
     if compression == 'zlib':
         rfile = ROOT.TFile.Open(filename, mode, "", 101)
     else:
-        rfile = ROOT.TFile.Open(filename, mode)
+        rfile = ROOT.TFile.Open(filename, mode, "", 201)
 
     if mode == 'update':
         tree = rfile.Get(treename)

--- a/utils/io.py
+++ b/utils/io.py
@@ -8,10 +8,10 @@ from pathlib import Path
 def array2root(array, filename,
                treename='tree', mode='update',
                compression='zlib'):
-    # Stolen from 'root_numpy', in:
+    # Main idea stolen from 'root_numpy', in:
     #   root_numpy/src/tree.pyx
 
-    # First, if the file is yet to exist, forcing 'recreate mode'
+    # Ff the file is yet to exist, forcing 'recreate' mode.
     target_file = Path(filename)
     if not target_file.is_file():
         mode = 'recreate'

--- a/utils/io.py
+++ b/utils/io.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 
 def array2root(array, filename,
-               treename='tree',
-               mode='update', compression='zlib'):
+               treename='tree', mode='update',
+               compression='zlib'):
     # Stolen from 'root_numpy', in:
     #   root_numpy/src/tree.pyx
 
@@ -17,9 +17,9 @@ def array2root(array, filename,
         mode = 'recreate'
 
     if compression == 'zlib':
-        rfile = ROOT.TFile(filename, mode, "", 101)
+        rfile = ROOT.TFile.Open(filename, mode, "", 101)
     else:
-        rfile = ROOT.TFile(filename, mode)
+        rfile = ROOT.TFile.Open(filename, mode)
 
     if mode == 'update':
         tree = rfile.Get(treename)
@@ -27,9 +27,12 @@ def array2root(array, filename,
     else:
         datatree = array2tree(array, name=treename)
 
-    # datatree.Write(treename, ROOT.TObject.kOverwrite)
+    # Possible alternative write modes:
+    #   ROOT.TObject.kWriteDelete, ROOT.TObject.kOverwrite
     rfile.Write("", ROOT.TObject.kOverwrite)
-    del datatree
+    # rfile.Write()
 
     rfile.Close()
+
+    del datatree
     del rfile


### PR DESCRIPTION
Now I can confirm that if we recreate our initial ROOT file so that its compression algorithm is explicitly specified, then subsequent update to the same file will maintain backward compatibility.

tl;dr: Just convert `DVntuple_MC16_backup.root` to a new file that has a `CompressionSettings` of `101`, instead of `1`. Then all subsequent update to that file will not break anything.